### PR TITLE
Fix 'Unknown or expired transaction ID.' in Mixer.InteractiveSample

### DIFF
--- a/Mixer.InteractiveSample/MainWindow.xaml.cs
+++ b/Mixer.InteractiveSample/MainWindow.xaml.cs
@@ -106,7 +106,7 @@ namespace Mixer.InteractiveSample
         private async void InteractiveClient_OnGiveInput(object sender, InteractiveGiveInputModel e)
         {
             this.InteractiveDataTextBlock.Text += "Input Received: " + e.participantID + " - " + e.input.eventType + " - " + e.input.controlID + Environment.NewLine;
-            if (e.input.eventType.Equals("mousedown"))
+            if (e.input.eventType.Equals("mousedown") && e.transactionID != null)
             {
                 if (await this.interactiveClient.CaptureSparkTransaction(e.transactionID))
                 {


### PR DESCRIPTION
Previously, the InteractiveClient_OnGiveInput method was throwing a Mixer.Base.Util.ReplyPacketException, due to not checking for a null transactionID. This bug occurred when interacting with an interactive control without a spark cost.